### PR TITLE
Use new S3 prod bucket to get MV information

### DIFF
--- a/pkg/mv/aws.go
+++ b/pkg/mv/aws.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	prodBucketName   = "solo-brkt-prod-net"
+	prodBucketName   = "metavisor-prod-net"
 	prodBucketRegion = "us-west-2"
 	mvPrefix         = "metavisor"
 

--- a/pkg/mv/list.go
+++ b/pkg/mv/list.go
@@ -50,13 +50,12 @@ func FormatMetavisors(mvs MetavisorVersions, withJSON bool) (string, error) {
 	var s bytes.Buffer
 	for i := range mvs.Versions {
 		if mvs.Versions[i] == mvs.Latest {
-			s.WriteString(fmt.Sprintf("%s (latest)\n", mvs.Versions[i]))
+			s.WriteString(fmt.Sprintf("%s (latest)", mvs.Versions[i]))
 		} else {
-			if i == len(mvs.Versions)-1 {
-				s.WriteString(mvs.Versions[i])
-			} else {
-				s.WriteString(fmt.Sprintf("%s\n", mvs.Versions[i]))
-			}
+			s.WriteString(mvs.Versions[i])
+		}
+		if i < len(mvs.Versions)-1 {
+			s.WriteString("\n")
 		}
 	}
 	return s.String(), nil


### PR DESCRIPTION
This also fixes a tiny bug where there would be an extra whitespace in the version list if it only contained the latest version.